### PR TITLE
Take picture options

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,10 +98,11 @@ export default class Camera extends Component {
   }
 
   // Take a picture of what is currently seen by the user.
+  // Possible options: width (int), height (int) and quality (float).
   // @return a Promise<String:uri>.
   // @warn Currently only works on iOS.
-  async takePicture() {
-    return await CameraManager.takePicture();
+  async takePicture(options) {
+    return await CameraManager.takePicture(options);
   }
 
   render() {


### PR DESCRIPTION
Added logic so that we can send some basic options to the takePicture call.

````
const options = { width: 1200, height: 1200, quality: 0.8 };
this.refs.camera.takePicture(options).then(
        uri => {
          console.log(uri);
        },
        error => {
          console.error(error);
        }
      );
````