### PR TITLE
Updating Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ yarn add react-native-openalpr
 #### Install pods
 
 ```sh
-$ cd ios && pod install && cd ...
+$ cd ios && pod install && cd ..
 ```
 
 #### Camera Permissions

--- a/README.md
+++ b/README.md
@@ -25,20 +25,6 @@ $ yarn add react-native-openalpr
 
 ### iOS Specific Setup
 
-#### Install react-native-permissions
-
-It is a good practice to check and request CAMERA permission. Check full implementation in example folder.
-
-```sh
-yarn add react-native-permissions
-```
-
-Add camera permission into your podfile.
-
-```
-pod 'Permission-Camera', :path => "../node_modules/react-native-permissions/ios/Camera.podspec"
-```
-
 #### Install pods
 
 ```sh


### PR DESCRIPTION
Since react-native now no longer needs `react-native-permissions` and instead pulls that info directly from the `react-native-openalpr.podspec` file, we no longer need to install the module and add the the permission path to the podfile. In fact, doing so will cause the application to fail compilation.

Also fixed an error where `cd ...` should be `cd ..`